### PR TITLE
Backwards compatibility for node < 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+const hasSemi = /;\s*$/
 module.exports = function addSemis (css) {
-  return css.replace(/(\w+\s*:[^{;}\n]+?)(\s*}|(?<!,\s*)\n|$)/g, '$1;$2')
+  return css.replace(/(\{\s*)([\s\S]+?)(\s*\})/g, function (matches, open, body, close) {
+    return open + body
+      .split('\n')
+      .map(function (line) {
+        const isEmpty = line.trim() === ''
+        return isEmpty || hasSemi.test(line) ? line : line + ';'
+      })
+      .join('\n') + close
+  })
 }


### PR DESCRIPTION
The lookback works fine in node 9 and newer browsers, but I'm not aware of any way yet to make it work in older browsers.

I've rewritten it to not need lookback any more.  We know that we'll only ever need to add semicolons inside a `{ ... }` block, so we can remove some complexity by coding that assumption in.